### PR TITLE
Rudimentary VMAP support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -73,6 +73,7 @@
     "Ad":true,
     "Linear":true,
     "Wrapper":true,
+    "AdSource":true,
     "VASTResponse":true,
     "TrackingEvent":true,
     "Creative":true,

--- a/src/ads/vast/client/Ad.js
+++ b/src/ads/vast/client/Ad.js
@@ -13,4 +13,12 @@ function Ad(adJTree) {
   if(adJTree.wrapper){
     this.wrapper = new Wrapper(adJTree.wrapper);
   }
+
+  if(adJTree.prefix === 'vmap' && adJTree.adSource){
+    this.source = new AdSource(adJTree.adSource);
+
+    this.id = adJTree.adSource.attr('breakId');
+    this.type = adJTree.attr('breakType');
+    this.timeOffset = adJTree.attr('timeOffset');
+  }
 }

--- a/src/ads/vast/client/AdSource.js
+++ b/src/ads/vast/client/AdSource.js
@@ -1,0 +1,15 @@
+function AdSource(adSourceJTree) {
+  if(!(this instanceof AdSource)) {
+    return new AdSource(adSourceJTree);
+  }
+
+  //Required elements
+  this.VASTAdTagURI = xml.keyValue(adSourceJTree.adTagURI);
+
+  //Optional elements
+  this.error = xml.keyValue(adSourceJTree.error);
+
+  //Optional attrs
+  this.followRedirects = adSourceJTree.attr('followRedirects') !== false;
+  this.allowMultipleAds = adSourceJTree.attr('allowMultipleAds');
+}

--- a/src/utils/xml.js
+++ b/src/utils/xml.js
@@ -61,7 +61,7 @@ xml.JXONTree = function JXONTree (oXMLParent) {
   //The document object is an especial object that it may miss some functions or attrs depending on the browser.
   //To prevent this problem with create the JXONTree using the root childNode which is a fully fleshed node on all supported
   //browsers.
-  if(oXMLParent.documentElement){
+  if (oXMLParent.documentElement) {
     return new xml.JXONTree(oXMLParent.documentElement);
   }
 
@@ -71,8 +71,8 @@ xml.JXONTree = function JXONTree (oXMLParent) {
       oNode = oXMLParent.childNodes.item(nItem);
       /*jshint bitwise: false*/
       if ((oNode.nodeType - 1 | 1) === 3) { sCollectedTxt += oNode.nodeType === 3 ? oNode.nodeValue.trim() : oNode.nodeValue; }
-      else if (oNode.nodeType === 1 && !oNode.prefix) {
-        sProp = decapitalize(oNode.nodeName);
+      else if (oNode.nodeType === 1) {
+        sProp = decapitalize(oNode.localName);
         vContent = new xml.JXONTree(oNode);
         if (this.hasOwnProperty(sProp)) {
           if (this[sProp].constructor !== Array) { this[sProp] = [this[sProp]]; }
@@ -92,6 +92,7 @@ xml.JXONTree = function JXONTree (oXMLParent) {
       this["@" + decapitalize(oAttrib.name)] = parseText(oAttrib.value.trim());
     }
   }
+  this.prefix = oXMLParent.prefix && decapitalize(oXMLParent.prefix);
 };
 
 xml.JXONTree.prototype.attr = function(attr) {

--- a/test/ads/vast/client/VASTClient.spec.js
+++ b/test/ads/vast/client/VASTClient.spec.js
@@ -498,8 +498,8 @@ describe("VASTClient", function () {
           '<VAST version="2.0"><Ad id="secondAd"></Ad></VAST>');
         this.clock.tick(1);
 
-        assertError(callback, 'on VASTClient.getVASTAd.validateAd, nor wrapper nor inline elements found on the Ad', 101);
-        assertErrorTrack('on VASTClient.getVASTAd.validateAd, nor wrapper nor inline elements found on the Ad', 101, ['firstAd', 'secondAd']);
+        assertError(callback, 'on VASTClient.getVASTAd.validateAd,  no wrapper, inline, or source element found on the Ad', 101);
+        assertErrorTrack('on VASTClient.getVASTAd.validateAd,  no wrapper, inline, or source element found on the Ad', 101, ['firstAd', 'secondAd']);
       });
 
       it("must return a 101 error to the callback and track it if one of the ads in the chain contains an inline with no creative", function(){
@@ -545,7 +545,7 @@ describe("VASTClient", function () {
           '<VAST version="2.0"><Ad id="adChain1"></Ad><Ad id="adChain2"><Wrapper><VASTAdTagURI><![CDATA[http://vastadtaguri.com]]></VASTAdTagURI><Error><![CDATA[http://t1.liverail.com/?metric=error&erc=[ERRORCODE]]]></Error></Wrapper></Ad></VAST>');
         this.clock.tick(1);
         //It must track the failed first error
-        assertErrorTrack("on VASTClient.getVASTAd.validateAd, nor wrapper nor inline elements found on the Ad", 101, ['adChain1']);
+        assertErrorTrack("on VASTClient.getVASTAd.validateAd,  no wrapper, inline, or source element found on the Ad", 101, ['adChain1']);
 
         requests[1].respond(200, {"Content-Type": "text"}, vastXML('<Ad id="adChain2.1"><InLine><Creatives><Creative><Linear>' +
           '<Duration>00:00:58</Duration>' +
@@ -569,7 +569,7 @@ describe("VASTClient", function () {
           '<VAST version="2.0"><Ad id="adChain1"></Ad><Ad id="adChain2"><Wrapper><VASTAdTagURI><![CDATA[http://vastadtaguri.com]]></VASTAdTagURI><Error><![CDATA[http://t1.liverail.com/?metric=error&erc=[ERRORCODE]]]></Error></Wrapper></Ad></VAST>');
         this.clock.tick(1);
         //It must track the failed first error
-        assertErrorTrack("on VASTClient.getVASTAd.validateAd, nor wrapper nor inline elements found on the Ad", 101, ['adChain1']);
+        assertErrorTrack("on VASTClient.getVASTAd.validateAd,  no wrapper, inline, or source element found on the Ad", 101, ['adChain1']);
 
         requests[1].respond(200, {"Content-Type": "text"}, vastXML('<Ad id="adChain2"><InLine><Creatives></Creatives></InLine></Ad>'));
         this.clock.tick(1);
@@ -587,7 +587,7 @@ describe("VASTClient", function () {
           '<VAST version="2.0"><Ad id="adChain1"></Ad><Ad id="adChain2"><Wrapper><VASTAdTagURI><![CDATA[http://vastadtaguri.com]]></VASTAdTagURI><Error><![CDATA[http://t1.liverail.com/?metric=error&erc=[ERRORCODE]]]></Error></Wrapper></Ad></VAST>');
         this.clock.tick(1);
         //It must track the failed first error
-        assertErrorTrack("on VASTClient.getVASTAd.validateAd, nor wrapper nor inline elements found on the Ad", 101, ['adChain1']);
+        assertErrorTrack("on VASTClient.getVASTAd.validateAd,  no wrapper, inline, or source element found on the Ad", 101, ['adChain1']);
 
         requests[1].respond(200, {"Content-Type": "text"}, vastXML('<Ad id="adChain2.1"><InLine><Creatives><Creative><Linear>' +
           '<Duration>00:00:58</Duration>' +
@@ -605,7 +605,7 @@ describe("VASTClient", function () {
 
     describe("_trackError", function(){
       var adChain;
-      
+
       beforeEach(function(){
         sinon.stub(vastUtil, 'track');
 


### PR DESCRIPTION
![I'm the map!](https://cloud.githubusercontent.com/assets/330938/11430410/4a10e004-9454-11e5-88c0-a456776dd8ff.gif)

At the moment, this will just pull the first ad it can out of the VMAP and play it as a pre-roll, regardless of its intended time offset. This is nowhere close to following VMAP specs (yet) but it's helpful to keep VMAP support development separate from other work.
